### PR TITLE
Localization 267a

### DIFF
--- a/Localization/README.md
+++ b/Localization/README.md
@@ -1,11 +1,11 @@
 # Localization
 The purpose of this folder is to store and track the localization exports from ACT, version to version.
-Starting ACT with the `-exportcontroltext` commandline switch will export easily localizable strings.
+Starting ACT with the `-exportcontroltext` commandline switch will export easily localizable strings.  To be safe, make a copy of ACT and run with `-portable` to avoid loading plugins and polluting the exports with extra tabs/controls.
 
 Each form will export a single XML file that can technically be used by the `-importcontroltext` switch, but should be used as a plugin resource and fed into a method such as [`ImportControlTextXML()`](https://advancedcombattracker.com/apidoc/?topic=html/M_Advanced_Combat_Tracker_FormActMain_ImportControlTextXML.htm).  
 
 Additionally ***.InternalStrings.cs** will also be exported with dynamically used strings.  (These should be sorted alphabetically to make tracking easier)
-This *.cs file can be directly loaded by ACT as a plugin, or you may compile the **ActLocalization.csproj** project to include the XML files as well.
+This *.cs file can be directly loaded by ACT as a plugin, or you may compile the **ActLocalization.csproj** project to include the XML files as well.  The CSProj can be compiled with this *.cs ***or*** the InternalStrings XML.
 
 Lastly, there will be localizable strings used in parsing/data.  These should be changed by parsing plugins, however secondary plugins loaded afterwards could also do this localization.  See the [EQ2 English parsing plugin](https://github.com/EQAditu/AdvancedCombatTracker/blob/master/Plugins/Standalone/ACT_English_Parser.cs#L1877) as a primary example of localizing all of these objects by replacing them.  ACT by default will start with these **EQ2 English** objects and plugins can remove these objects and recreate them with different localized strings.
 

--- a/Localization/en-US/ActLocalization.csproj
+++ b/Localization/en-US/ActLocalization.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -44,7 +44,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ActLocalizationPlugin.cs" />
-    <Compile Include="Advanced Combat Tracker.exe.InternalStrings.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Advanced Combat Tracker.exe.FormActMain.xml" />
@@ -67,6 +66,9 @@
     <EmbeddedResource Include="Advanced Combat Tracker.exe.FormTimeLine.xml" />
     <EmbeddedResource Include="Advanced Combat Tracker.exe.FormUpdater.xml" />
     <EmbeddedResource Include="Advanced Combat Tracker.exe.FormXmlSettingsIO.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Advanced Combat Tracker.exe.InternalStrings.xml" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Localization/en-US/Advanced Combat Tracker.exe.InternalStrings.xml
+++ b/Localization/en-US/Advanced Combat Tracker.exe.InternalStrings.xml
@@ -1,0 +1,577 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<InternalStrings>
+	<!--attackTypeTerm-all -> The localized term for an AttackType object that contains swings merged from other AttackTypes-->
+	<string key="attackTypeTerm-all" value="All" />
+	<string key="btnFeedbackSubmit-Text2" value="Please restart to submit more." />
+	<string key="data-dnumBlock" value="Block" />
+	<string key="data-dnumDeath" value="Death" />
+	<string key="data-dnumMiss" value="Miss" />
+	<string key="data-dnumNoDamage" value="No Damage" />
+	<string key="data-dnumParry" value="Parry" />
+	<string key="data-dnumResist" value="Resist" />
+	<string key="data-dnumRiposte" value="Riposte" />
+	<string key="data-timerStringNone" value="&lt;None&gt;" />
+	<string key="encounterData-defaultEncounterName" value="Encounter" />
+	<!--exportFormattingDesc-critheal% -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-critheal%" value="The percentage of heals that were critical." />
+	<!--exportFormattingDesc-critheals -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-critheals" value="The number of heals that were critical." />
+	<!--exportFormattingDesc-crithit% -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-crithit%" value="The percentage of damaging attacks that were critical." />
+	<!--exportFormattingDesc-crithits -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-crithits" value="The number of damaging attacks that were critical." />
+	<!--exportFormattingDesc-cures -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-cures" value="The total number of times the combatant cured or dispelled" />
+	<!--exportFormattingDesc-custom -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-custom" value="Enter your custom text into the above text box before appending." />
+	<!--exportFormattingDesc-damage -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-damage" value="The amount of damage from auto-attack, spells, CAs, etc done to other combatants." />
+	<!--exportFormattingDesc-damage% -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-damage%" value="This value represents the percent share of all damage done by allies in this encounter." />
+	<!--exportFormattingDesc-damagetaken -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-damagetaken" value="The total amount of damage this combatant received." />
+	<!--exportFormattingDesc-deaths -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-deaths" value="The total number of times this character was killed by another." />
+	<!--exportFormattingDesc-dps -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-dps" value="The damage total of the combatant divided by their personal duration, formatted as 12.34" />
+	<!--exportFormattingDesc-DPS -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-DPS" value="The damage total of the combatatant divided by their personal duration, formatted as 12" />
+	<!--exportFormattingDesc-duration -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-duration" value="The duration of the combatant or the duration of the encounter, displayed as mm:ss" />
+	<!--exportFormattingDesc-DURATION -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-DURATION" value="The duration of the combatant or encounter displayed in whole seconds." />
+	<!--exportFormattingDesc-extdps -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-extdps" value="The damage total of the combatant divided by the duration of the encounter, formatted as 12.34 -- This is more commonly used than DPS" />
+	<!--exportFormattingDesc-EXTDPS -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-EXTDPS" value="The damage total of the combatant divided by the duration of the encounter, formatted as 12 -- This is more commonly used than DPS" />
+	<!--exportFormattingDesc-exthps -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-exthps" value="The healing total of the combatant divided by the duration of the encounter, formatted as 12.34" />
+	<!--exportFormattingDesc-EXTHPS -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-EXTHPS" value="The healing total of the combatant divided by the duration of the encounter, formatted as 12" />
+	<!--exportFormattingDesc-healed -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-healed" value="The numerical total of all heals, wards or similar sourced from this combatant." />
+	<!--exportFormattingDesc-healed% -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-healed%" value="This value represents the percent share of all healing done by allies in this encounter." />
+	<!--exportFormattingDesc-heals -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-heals" value="The total number of heals from this combatant." />
+	<!--exportFormattingDesc-healstaken -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-healstaken" value="The total amount of healing this combatant received." />
+	<!--exportFormattingDesc-hitfailed -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-hitfailed" value="Any type of failed attack that was not a miss.  This includes resists, reflects, blocks, dodging, etc." />
+	<!--exportFormattingDesc-hits -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-hits" value="The number of attack attempts that produced damage.  IE a spell successfully doing damage." />
+	<!--exportFormattingDesc-kills -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-kills" value="The total number of times this character landed a killing blow." />
+	<!--exportFormattingDesc-maxheal -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-maxheal" value="The highest single healing amount formatted as [Combatant-]SkillName-Healing#" />
+	<!--exportFormattingDesc-MAXHEAL -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-MAXHEAL" value="The highest single healing amount formatted as [Combatant-]Healing#" />
+	<!--exportFormattingDesc-maxhealward -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-maxhealward" value="The highest single healing/warding amount formatted as [Combatant-]SkillName-Healing#" />
+	<!--exportFormattingDesc-MAXHEALWARD -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-MAXHEALWARD" value="The highest single healing/warding amount formatted as [Combatant-]Healing#" />
+	<!--exportFormattingDesc-maxhit -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-maxhit" value="The highest single damaging hit formatted as [Combatant-]SkillName-Damage#" />
+	<!--exportFormattingDesc-MAXHIT -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-MAXHIT" value="The highest single damaging hit formatted as [Combatant-]Damage#" />
+	<!--exportFormattingDesc-misses -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-misses" value="The number of auto-attacks or CAs that produced a miss message." />
+	<!--exportFormattingDesc-name -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-name" value="The combatant's name." />
+	<!--exportFormattingDesc-NAME -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-NAME" value="The combatant's name shortened to a number of characters after a colon, like: &quot;NAME:5&quot;" />
+	<!--exportFormattingDesc-NAME10 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-NAME10" value="The combatant's name, up to 10 characters will be displayed." />
+	<!--exportFormattingDesc-NAME11 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-NAME11" value="The combatant's name, up to 11 characters will be displayed." />
+	<!--exportFormattingDesc-NAME12 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-NAME12" value="The combatant's name, up to 12 characters will be displayed." />
+	<!--exportFormattingDesc-NAME13 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-NAME13" value="The combatant's name, up to 13 characters will be displayed." />
+	<!--exportFormattingDesc-NAME14 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-NAME14" value="The combatant's name, up to 14 characters will be displayed." />
+	<!--exportFormattingDesc-NAME15 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-NAME15" value="The combatant's name, up to 15 characters will be displayed." />
+	<!--exportFormattingDesc-NAME3 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-NAME3" value="The combatant's name, up to 3 characters will be displayed." />
+	<!--exportFormattingDesc-NAME4 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-NAME4" value="The combatant's name, up to 4 characters will be displayed." />
+	<!--exportFormattingDesc-NAME5 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-NAME5" value="The combatant's name, up to 5 characters will be displayed." />
+	<!--exportFormattingDesc-NAME6 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-NAME6" value="The combatant's name, up to 6 characters will be displayed." />
+	<!--exportFormattingDesc-NAME7 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-NAME7" value="The combatant's name, up to 7 characters will be displayed." />
+	<!--exportFormattingDesc-NAME8 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-NAME8" value="The combatant's name, up to 8 characters will be displayed." />
+	<!--exportFormattingDesc-NAME9 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-NAME9" value="The combatant's name, up to 9 characters will be displayed." />
+	<!--exportFormattingDesc-newline -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-newline" value="Formatting after this element will appear on a new line." />
+	<!--exportFormattingDesc-powerdrain -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-powerdrain" value="The amount of power this combatant drained from others." />
+	<!--exportFormattingDesc-powerheal -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-powerheal" value="The amount of power this combatant replenished to others." />
+	<!--exportFormattingDesc-swings -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-swings" value="The number of attack attempts.  This includes any auto-attacks or abilities, also including resisted abilities that do no damage." />
+	<!--exportFormattingDesc-tab -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-tab" value="Formatting after this element will appear in a relative column arrangement.  (The formatting example cannot display this properly)" />
+	<!--exportFormattingDesc-threatdelta -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-threatdelta" value="The amount of direct threat output relative to zero." />
+	<!--exportFormattingDesc-threatstr -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-threatstr" value="The amount of direct threat output that was increased/decreased." />
+	<!--exportFormattingDesc-title -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-title" value="The title of the completed encounter.  This may only be used in Allies formatting." />
+	<!--exportFormattingDesc-tohit -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-tohit" value="The percentage of hits to swings as 12.34" />
+	<!--exportFormattingDesc-TOHIT -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingDesc-TOHIT" value="The percentage of hits to swings as 12" />
+	<!--exportFormattingLabel-critheal% -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-critheal%" value="Critical Heal Percentage" />
+	<!--exportFormattingLabel-critheals -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-critheals" value="Critical Heal Count" />
+	<!--exportFormattingLabel-crithit% -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-crithit%" value="Critical Hit Percentage" />
+	<!--exportFormattingLabel-crithits -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-crithits" value="Critical Hit Count" />
+	<!--exportFormattingLabel-cures -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-cures" value="Cure or Dispel Count" />
+	<string key="exportFormattingLabel-custom" value="Custom Text" />
+	<!--exportFormattingLabel-damage -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-damage" value="Damage" />
+	<!--exportFormattingLabel-damage% -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-damage%" value="Damage %" />
+	<!--exportFormattingLabel-damagetaken -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-damagetaken" value="Damage Received" />
+	<!--exportFormattingLabel-deaths -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-deaths" value="Deaths" />
+	<!--exportFormattingLabel-dps -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-dps" value="DPS" />
+	<!--exportFormattingLabel-DPS -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-DPS" value="Short DPS" />
+	<!--exportFormattingLabel-duration -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-duration" value="Duration" />
+	<!--exportFormattingLabel-DURATION -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-DURATION" value="Short Duration" />
+	<!--exportFormattingLabel-extdps -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-extdps" value="Encounter DPS" />
+	<!--exportFormattingLabel-EXTDPS -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-EXTDPS" value="Short Encounter DPS" />
+	<!--exportFormattingLabel-exthps -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-exthps" value="Encounter HPS" />
+	<!--exportFormattingLabel-EXTHPS -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-EXTHPS" value="Short Encounter HPS" />
+	<!--exportFormattingLabel-healed -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-healed" value="Healed" />
+	<!--exportFormattingLabel-healed% -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-healed%" value="Healed %" />
+	<!--exportFormattingLabel-heals -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-heals" value="Heal Count" />
+	<!--exportFormattingLabel-healstaken -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-healstaken" value="Healing Received" />
+	<!--exportFormattingLabel-hitfailed -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-hitfailed" value="Other Avoid" />
+	<!--exportFormattingLabel-hits -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-hits" value="Hits" />
+	<!--exportFormattingLabel-kills -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-kills" value="Killing Blows" />
+	<!--exportFormattingLabel-maxheal -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-maxheal" value="Highest Heal" />
+	<!--exportFormattingLabel-MAXHEAL -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-MAXHEAL" value="Short Highest Heal" />
+	<!--exportFormattingLabel-maxhealward -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-maxhealward" value="Highest Heal/Ward" />
+	<!--exportFormattingLabel-MAXHEALWARD -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-MAXHEALWARD" value="Short Highest Heal/Ward" />
+	<!--exportFormattingLabel-maxhit -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-maxhit" value="Highest Hit" />
+	<!--exportFormattingLabel-MAXHIT -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-MAXHIT" value="Short Highest Hit" />
+	<!--exportFormattingLabel-misses -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-misses" value="Misses" />
+	<!--exportFormattingLabel-name -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-name" value="Name" />
+	<!--exportFormattingLabel-NAME -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-NAME" value="Short Name" />
+	<!--exportFormattingLabel-NAME10 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-NAME10" value="Name (10 chars)" />
+	<!--exportFormattingLabel-NAME11 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-NAME11" value="Name (11 chars)" />
+	<!--exportFormattingLabel-NAME12 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-NAME12" value="Name (12 chars)" />
+	<!--exportFormattingLabel-NAME13 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-NAME13" value="Name (13 chars)" />
+	<!--exportFormattingLabel-NAME14 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-NAME14" value="Name (14 chars)" />
+	<!--exportFormattingLabel-NAME15 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-NAME15" value="Name (15 chars)" />
+	<!--exportFormattingLabel-NAME3 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-NAME3" value="Name (3 chars)" />
+	<!--exportFormattingLabel-NAME4 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-NAME4" value="Name (4 chars)" />
+	<!--exportFormattingLabel-NAME5 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-NAME5" value="Name (5 chars)" />
+	<!--exportFormattingLabel-NAME6 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-NAME6" value="Name (6 chars)" />
+	<!--exportFormattingLabel-NAME7 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-NAME7" value="Name (7 chars)" />
+	<!--exportFormattingLabel-NAME8 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-NAME8" value="Name (8 chars)" />
+	<!--exportFormattingLabel-NAME9 -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-NAME9" value="Name (9 chars)" />
+	<!--exportFormattingLabel-newline -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-newline" value="New Line" />
+	<!--exportFormattingLabel-powerdrain -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-powerdrain" value="Power Drain" />
+	<!--exportFormattingLabel-powerheal -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-powerheal" value="Power Replenish" />
+	<!--exportFormattingLabel-swings -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-swings" value="Swings (Attacks)" />
+	<!--exportFormattingLabel-tab -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-tab" value="Tab Character" />
+	<!--exportFormattingLabel-threatdelta -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-threatdelta" value="Threat Delta" />
+	<!--exportFormattingLabel-threatstr -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-threatstr" value="Threat Increase/Decrease" />
+	<!--exportFormattingLabel-title -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-title" value="Encounter Title" />
+	<!--exportFormattingLabel-tohit -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-tohit" value="To Hit %" />
+	<!--exportFormattingLabel-TOHIT -> DEPRECATED: Only old plugins use this.-->
+	<string key="exportFormattingLabel-TOHIT" value="Short To Hit %" />
+	<string key="graphAdv-termDps" value="DPS" />
+	<!--graphAdv-toolTip -> sec = second-->
+	<string key="graphAdv-toolTip" value="+{0} ({1} sec average)" />
+	<!--graphCombatant-toolTip -> sec = second-->
+	<string key="graphCombatant-toolTip" value="+{0} ({1:#,0} sec average)" />
+	<!--helpPanel-btnExportUIBrowser -> Help Panel Mouseover-->
+	<string key="helpPanel-btnExportUIBrowser" value="Press this button to start a wizard allowing you to set the EQ2's web browser to ACT's encounter index and optionally extracting a browser UI replacement with a collapsable interface and controls for maximum screen space." />
+	<string key="helpPanel-btnImportFile" value="To import encounters from your logfile, select the start and ending date with the choosers and select the log file to parse." />
+	<!--helpPanel-btnOdbcDropTables -> Help Panel Mouseover-->
+	<string key="helpPanel-btnOdbcDropTables" value="This will perform the DROP command on each table ACT uses.  This will delete all table data and remove the tables from the datasource." />
+	<!--helpPanel-btnOdbcTestConnection -> Help Panel Mouseover-->
+	<string key="helpPanel-btnOdbcTestConnection" value="This will attempt to log into the ODBC datasource specified in the Connection String." />
+	<!--helpPanel-btnOdbcValidateTables -> Help Panel Mouseover-->
+	<string key="helpPanel-btnOdbcValidateTables" value="This will make sure the ODBC datasource has the required tables and the tables have the required columns.  If anything is missing, ACT will attempt to create or alter the tables.  Success is required to do SQL exporting." />
+	<string key="helpPanel-btnResetColors" value="Resetting color/font settings will require ACT to be restarted." />
+	<!--helpPanel-btnResetOdbcHacks -> Help Panel Mouseover-->
+	<string key="helpPanel-btnResetOdbcHacks" value="This button will delete all ODBC hacks and replace them with a set of known hacks for various datasources, such as MSSQL, MS Access, Postgres..." />
+	<string key="helpPanel-cbAutoLoadLogs" value="ACT should check every few seconds for existing logs to have been updated and switch to those currently used logs.  (It will not check for new files automatically)" />
+	<!--helpPanel-cbBlockisHit -> Help Panel Mouseover-->
+	<string key="helpPanel-cbBlockisHit" value="When checked, a hit that reports that it fails to inflict any damage will still be considered a Hit.  When unchecked, only an attack that does damage is considered successful." />
+	<!--helpPanel-cbCullAll -> Help Panel Mouseover-->
+	<string key="helpPanel-cbCullAll" value="When a new zone listing is created, ACT will keep the listed number of &quot;All&quot; zone-wide encounters and cull the older." />
+	<!--helpPanel-cbCullCount -> Help Panel Mouseover-->
+	<string key="helpPanel-cbCullCount" value="When an encounter ends, normal encounters are culled to the listed number.  This applies to encounters in any current or previous zone but will not affect &quot;All&quot; zone-wide encounters." />
+	<!--helpPanel-cbCullCountIgnoreNoAlly -> Help Panel Mouseover-->
+	<string key="helpPanel-cbCullCountIgnoreNoAlly" value="Encounters with no allies, marked &quot;Encounter&quot; will not add to the count when determining the number of old encounters to cull." />
+	<!--helpPanel-cbCullNoAlly -> Help Panel Mouseover-->
+	<string key="helpPanel-cbCullNoAlly" value="When an encounter ends, all encounters (except for the last) labeled &quot;Encounter&quot; will be removed." />
+	<!--helpPanel-cbCullOther -> Help Panel Mouseover-->
+	<string key="helpPanel-cbCullOther" value="When a new zone listing is created, ACT will keep the normal encounters of this many previous zones." />
+	<!--helpPanel-cbCullTimer -> Help Panel Mouseover-->
+	<string key="helpPanel-cbCullTimer" value="When an encounter ends, all encounters (except for &quot;All&quot; zone-wide encounters) older than this time limit will be removed." />
+	<!--helpPanel-cbCurrentOdbc -> Help Panel Mouseover-->
+	<string key="helpPanel-cbCurrentOdbc" value="When in combat, ACT can export to a temporary table called current_table on your ODBC datasource every few seconds.  Every export, the table will be deleted and refilled to reflect the current encounter.  This option is only recommended if you have a very quick connection to your datasource." />
+	<!--helpPanel-cbDoubleBufferLV -> Help Panel Mouseover-->
+	<string key="helpPanel-cbDoubleBufferLV" value="When checked, ACT will attempt to enable minimal redrawing of the main table.  Windows versions before WindowsXP normally do not have this ability and may cause undesired results." />
+	<!--helpPanel-cbExFile -> Help Panel Mouseover-->
+	<string key="helpPanel-cbExFile" value="At the end of combat, this option will export to a macro file something similar to what a clipboard export would look like.  This file export is not restricted to 256 characters like the clipboard export, however it can only output 16 lines.  Once the export is created, you can display the results by using the command:&#xA;&#xA;/do_file_commands act-export.txt&#xA;&#xA;You can create an EQ2 macro to trigger this command.  The macro file export will attempt to tabulate the data to make viewing it easier.&#xA;&#xA;You must set the below option with what channel you wish to display the export to beforehand.  Leaving the channel prefix blank will cause the macro file not to function unless the Text Only Formatting options prefix a channel to *every* line." />
+	<string key="helpPanel-cbExFileColumnAlign" value="When enabled, the text export will be aligned into a table where each cell is padded to the length of the longest entry in that column.  It is recommended you use a text formatter such as {NAME10} instead of {name} or that column may have excessive padding." />
+	<!--helpPanel-cbExGraph -> Help Panel Mouseover-->
+	<string key="helpPanel-cbExGraph" value="When checked, HTML exports will include a main encounter graph." />
+	<!--helpPanel-cbExHTML -> Help Panel Mouseover-->
+	<string key="helpPanel-cbExHTML" value="EQ2 comes with an integrated web browser based on FireFox.  This can be used to view data exported by ACT while in fullscreen.  The main encounter table will be exported as HTML to be viewed within the EQ2 HTML window.  To access the HTML window, type: &quot;/browser&quot;" />
+	<!--helpPanel-cbExHTMLFTP -> Help Panel Mouseover-->
+	<string key="helpPanel-cbExHTMLFTP" value="If checked, when ACT exports EQ2 compatible HTML files, it will attempt to upload them to an FTP server of your choice.  Make sure to test your settings before use." />
+	<!--helpPanel-cbExOdbc -> Help Panel Mouseover-->
+	<string key="helpPanel-cbExOdbc" value="This will enable SQL exporting via ODBC automatically when an encounter ends.&#xA;&#xA;To use this feature, you need an ODBC driver to connect to your datasource and to fill out the Connection String with the remote host info. http://connectionstrings.com/ can help you make a connection string for your specific SQL datasource." />
+	<!--helpPanel-cbExportBeep -> Help Panel Mouseover-->
+	<string key="helpPanel-cbExportBeep" value="When checked, any exporting to the clipboard will cause a default system beep.  This is a good indication of when an encounter is ended and there is new data to paste into EQ2." />
+	<!--helpPanel-cbExportFilterSpace -> Help Panel Mouseover-->
+	<string key="helpPanel-cbExportFilterSpace" value="When checked, the Mini Parse window and clipboard exporting will exclude any combatants with spaces in their names.  This will exclude most mobs such as 'a giant bat' or 'King Drayek', but not 'Anguis' or 'Frostbite'." />
+	<!--helpPanel-cbExText -> Help Panel Mouseover-->
+	<string key="helpPanel-cbExText" value="Combatant summaries for the encounter will be exported to the clipboard after an encounter has ended.  These summaries can be pasted into EQ2 by pressing Ctrl-V, and customized under General Options -&gt; Text Only Formatting -&gt; Clipboard Export Formatting." />
+	<string key="helpPanel-cbGCollectOnClear" value="Enabling this will cause ACT to call GCCollect when clearing the encounters.  Doing this will cause the Clear Encounters button to take longer and has been known to completely freeze ACT until restart.  Only use this if you have problems with ACT never freeing memory over time." />
+	<!--helpPanel-cbGermanMergeNames -> Help Panel Mouseover-->
+	<string key="helpPanel-cbGermanMergeNames" value="If enabled, combatants with grammatical changes such as: ruhiger Wachposten, ruhigen Wachpostens s, ruhigen Wachposten, ruhige Wachposten, ruhigen Wachposten en; will all show up as the same combatant.  (Which ever showed up first in an encounter)" />
+	<!--helpPanel-cbGExpEnd -> Help Panel Mouseover-->
+	<string key="helpPanel-cbGExpEnd" value="If 'You gain bonus experience for defeating the encounter!' is seen, the encounter will be considered ended. &#xA;('You convert experience into achievement experience!' twice in a single second will also trigger this.)" />
+	<!--helpPanel-cbGraphSoloInc -> Help Panel Mouseover-->
+	<string key="helpPanel-cbGraphSoloInc" value="When unchecked, solo combatant graphs will only show DPS lines for outgoing damage.  When checked, incoming damage and incoming heal DPS lines will also be generated.  (This will slightly increase the CPU time used to generate)" />
+	<!--helpPanel-cbHtmlTimers -> Help Panel Mouseover-->
+	<string key="helpPanel-cbHtmlTimers" value="When checked, ACT will export an HTML page displaying the current view of the Timers Window.  The timer view will have the same dimensions as the original window, so resize it to your needs." />
+	<!--helpPanel-cbIdleEnd -> Help Panel Mouseover-->
+	<string key="helpPanel-cbIdleEnd" value="If no combat actions such as attacking are observed for N number of seconds, the encounter will be considered ended." />
+	<!--helpPanel-cbIdleTimerEnd -> Help Panel Mouseover-->
+	<string key="helpPanel-cbIdleTimerEnd" value="A previously defaulted non-option, ACT can internally count seconds of inactivity instead of waiting on a log timestamp with a time sufficiently after the last combat action.  If disabled, ACT will only end encounters based off of timestamps, and if no new log lines are parsed, its possible to never end an encounter *until* a new log timestamp is seen from EQ2.  When enabled, the timer will not strictly end an encounter based off the timer, but two seconds after (in absense of log timestamps)." />
+	<!--helpPanel-cbKillEnd -> Help Panel Mouseover-->
+	<string key="helpPanel-cbKillEnd" value="When an allied combatant kills another, the encounter will be considered ended." />
+	<string key="helpPanel-cbLcdEnabled" value="This will enable ACT's support for the G15 and G19 keyboards, or other devices that use those unified drivers.  For the default applets: button 1 of 4(G15) or Menu button(G19) will change ACT modes.  The next button(G15) or OK button(G19) will usually change sub-modes within that mode, such as switching export formats." />
+	<!--helpPanel-cbLcdRoute -> Help Panel Mouseover-->
+	<string key="helpPanel-cbLcdRoute" value="When the ACT Clipboard Sharer is connected, using this option will route all LCD traffic to the G15 LCD on the connected computer's keyboard.  This allows you to run ACT on a different computer than EQ2 and retain all LCD functionality." />
+	<!--helpPanel-cbLongEncDuration -> Help Panel Mouseover-->
+	<string key="helpPanel-cbLongEncDuration" value="Previously when only using timed encounter ending, heals being cast while the delay was counting down could affect the encounter's total duration, and therefore ExtDPS.  If unchecked, heals after the last combat action will still be recorded up until the encounter is terminated, but will not affect the duration of the encounter." />
+	<!--helpPanel-cbMiniClickThrough -> Help Panel Mouseover-->
+	<string key="helpPanel-cbMiniClickThrough" value="When enabled, mouse actions will not affect the Mini Window.  When transparency is set, this allows you to both see through and click on things behind the window.  Of course you can no longer move or close the window by normal means until click-through is disabled.  NOTE: You may toggle this option by right-clicking the main window 'Show Mini' button." />
+	<string key="helpPanel-cbMiniColumnAlign" value="When enabled, the text export will be aligned into a table where each cell is padded to the length of the longest entry in that column.  The alignment is dependant on the font selected.  It is recommended you use a text formatter such as {NAME10} instead of {name} or that column may have excessive padding." />
+	<!--helpPanel-cbMultiDamageIsOne -> Help Panel Mouseover-->
+	<string key="helpPanel-cbMultiDamageIsOne" value="When enabled, an attack that has multiple damage types, such as &quot;300 crushing, 5 poison and 5 disease damage&quot; will show up as one total attack: 300/5/5 crushing/poison/disease, internally seen as 310.  If disabled, each damage type will show up as an individual swing, IE three attacks: 300 crushing; 5 poison; 5 disease.  Having a single attack show up as multiple will have consequences when calculating ToHit%." />
+	<!--helpPanel-cbOnlyGraphAllies -> Help Panel Mouseover-->
+	<string key="helpPanel-cbOnlyGraphAllies" value="When checked, simple encounter bar graphs will only show your allies." />
+	<!--helpPanel-cbPetIsMaster -> Help Panel Mouseover-->
+	<string key="helpPanel-cbPetIsMaster" value="When checked, a pet will not show as its own entry, but as a spell under their master.  When unchecked, the pet is considered a seperate combatant and has its own statistics unrelated to its master.&#xA;This setting is not retroactive, and will not combine or seperate a pet from its master if the encounter has already taken place.  Only future encounters will be affected by this setting.&#xA;&#xA;&#xA;Since LU19 and &lt;Purpose tags&gt; showing under a pet's name and not in log files, parsers cannot automatically see who a pet belongs to." />
+	<!--helpPanel-cbRecalcWardedHits -> Help Panel Mouseover-->
+	<string key="helpPanel-cbRecalcWardedHits" value="If enabled, no-damage hits or reduced damage hits immediately following a ward absorbtion will be increased by the absorbtion amount.  Stoneskin's no-damage hits cannot be recalculated." />
+	<!--helpPanel-cbRecordLogs -> Help Panel Mouseover-->
+	<string key="helpPanel-cbRecordLogs" value="When checked, ACT will record all log lines that appear during an encounter.  You may then right click an encounter, select View Logs and view/search through them.  Disabling this option will reduce memory usage by a bit less than 45% when compared to default settings.  Exported ACT files will retain these recorded logs." />
+	<!--helpPanel-cbRestrictToAll -> Help Panel Mouseover-->
+	<string key="helpPanel-cbRestrictToAll" value="When checked, under each combatant, the only Damage Types entries that will be fully populated will be the ones marked (Ref) for Reference.  Instead of 'Melee (Out)' showing All, crush, and slash it will only show All, which is a combination of crush/slash.  Crush and slash will still be found under 'All Outgoing (Ref)' due to the (Ref) tag; the listing will simply be more crowded.&#xA;Enabling this options willl reduce CPU usage by a bit less than 10% and reduce memory usage by a bit more than 10% when compared to default settings.  Unchecked, this option will populate all entries in their logical listings." />
+	<!--helpPanel-cbSExpEnd -> Help Panel Mouseover-->
+	<string key="helpPanel-cbSExpEnd" value="If 'You gain experience!' is seen, the encounter will be considered ended. &#xA;('You convert experience into achievement experience!' will also trigger this.)" />
+	<!--helpPanel-cbSqlSafeMode -> Help Panel Mouseover-->
+	<string key="helpPanel-cbSqlSafeMode" value="In safe mode, SQL commands will be sent one at a time and server response checked.  Otherwise commands will be sent in 100 row batches, which while faster will be more problematic to debug." />
+	<!--helpPanel-cbSwarmIsMaster -> Help Panel Mouseover-->
+	<string key="helpPanel-cbSwarmIsMaster" value="When enabled, &quot;Дух огня (персонажа)&quot;, &quot;Wässrige Horde des Character&quot; and other similarly named pets will have their attack damage added to their master instead of as their own named entry.  Incoming attacks will *not* be redirected to their master's data." />
+	<!--helpPanel-cbWebServerEnabled -> Help Panel Mouseover-->
+	<string key="helpPanel-cbWebServerEnabled" value="The ACT Web Interface is somewhat similar to the EQ2 HTML exports in appearance.  Dissimilarly, the web interface is not made up of intermediary HTML files but generated HTML upon request.  By default, you can see auto-updating pages of the current encounter table, Mini-Window text(with support for multiple presets), spell timers and a page that can browse through all of ACT's encounter data in memory.  Context-menu reports based on that data are not currently available but plugins can be made to expand the web interface." />
+	<!--helpPanel-cbWebServerShowReq -> Help Panel Mouseover-->
+	<string key="helpPanel-cbWebServerShowReq" value="If enabled, all HTTP requests will be shown.  Otherwise things like auto-updating portions of pages or .css/.js files will be hidden (unless very large).  One request to '/timers'(always shown) may initiate requests to '/ACT.js', '/ACT.css' and '/timers.body'(optionally shown) as well." />
+	<!--helpPanel-cbZoneAllListing -> Help Panel Mouseover-->
+	<string key="helpPanel-cbZoneAllListing" value="As the first encounter of each Zone branch, an &quot;All&quot; entry can exist which will combine all data from other encounters for that zone.  As encounters progress within that zone, the All entry will be updated in real time.  The All encounter entry will be identical to a merged encounter of all encounters within that zone.&#xA;&#xA;Disabling this option will reduce memory and CPU usage a bit more than 10% when compared to default options." />
+	<string key="helpPanel-ccDGAllyText" value="The foreground color of combatant names that are marked as allies." />
+	<string key="helpPanel-ccDGPersonalBackcolor" value="The background color of the main table row containing your combatant." />
+	<string key="helpPanel-ccEncLabel1" value="The color for encounters where all enemies have been defeated." />
+	<string key="helpPanel-ccEncLabel2" value="The color for encounters where the outcome was unknown." />
+	<string key="helpPanel-ccEncLabel3" value="The color for encounters where all allies were defeated." />
+	<string key="helpPanel-ColorRestart" value="Changing these colors will require ACT to be restarted." />
+	<!--helpPanel-CurrentExports -> Help Panel Mouseover-->
+	<string key="helpPanel-CurrentExports" value="Checking this will create a custom HTML page with an auto updating graph or table.  The page will auto-refresh at the user specified interval providing more or less a real-time view of the encounter." />
+	<!--helpPanel-ddlGraphPriority -> Help Panel Mouseover-->
+	<string key="helpPanel-ddlGraphPriority" value="This setting will change the priority of graph generation.  All programs have a priority, usually Normal by default, and this priority defines how much CPU time should be given to the current task.  If set to Lowest(Idle), graph generation will only take CPU time not used by other applications.  If EQ2 is running, this will be next to nothing.  Normal priority will give equal amounts of CPU time to ACT and any other task, such as EQ2. Above Normal(Not recommended) will give graph generation more priority than most other programs and may cause noticable stuttering in EQ2 momentary freezing.  ACT's UI may also become unresponsive during graph generation." />
+	<!--helpPanel-ddlLanguage -> Help Panel Mouseover-->
+	<string key="helpPanel-ddlLanguage" value="This will change the parsing engine to another language or Spell Timers only mode." />
+	<!--helpPanel-ExFTPPASV -> Help Panel Mouseover-->
+	<string key="helpPanel-ExFTPPASV" value="If you are behind a router or have multiple NICs you may need to use Passive mode transfers.  If the target FTP server is under the same conditions(a PASV only state), you must use Active mode.  Two machines that require PASV mode cannot establish FTP transfers." />
+	<!--helpPanel-gbOdbcHacks -> Help Panel Mouseover-->
+	<string key="helpPanel-gbOdbcHacks" value="This section contains rules to modify all commands sent to the datasource if the connection string matches the rule.  You may use the Reset button to pre-populate known rules for reference." />
+	<!--helpPanel-GraphSize -> Help Panel Mouseover-->
+	<string key="helpPanel-GraphSize" value="This will set the image dimentions of the graph in HTML exporting and EQ2 viewing." />
+	<!--helpPanel-GraphType -> Help Panel Mouseover-->
+	<string key="helpPanel-GraphType" value="Select a graphing method for the main encounter display." />
+	<string key="helpPanel-IO_ExportAct" value="This feature will export a compressed binary file which can be later imported by ACT to recreate the encounter.  If you wish to export more than one encounter as a single file, use the Show Checkboxes feature on the Main tab." />
+	<string key="helpPanel-IO_ExportHtml" value="This feature will export the selected encounters into a single static HTML file which is then controlled by JavaScript and CSS." />
+	<string key="helpPanel-IO_ImportAct" value="This feature is specifically for importing *.act files exported by ACT." />
+	<string key="helpPanel-IO_ImportClip" value="Press the Import Clipboard button to import the clipboard contents as though importing a log file." />
+	<string key="helpPanel-IO_ImportLog" value="Select the starting and end points before selecting the file to parse." />
+	<string key="helpPanel-IO_XmlFile" value="This feature was added by user request.  I don't know of any practical use for it." />
+	<string key="helpPanel-lblExFileLines" value="ACT will only create macro files with up to this many commands.  NOTE: EQ2 has server side filtering to prevent spam in public channels.  No matter what, you cannot exceed 16 chat commands in a public channel within a short amount of time." />
+	<string key="helpPanel-lblExportSound" value="The sound for when ACT creates clipboard exports, macro exports, etc either manually or immediately after combat." />
+	<string key="helpPanel-lblLcdMiniFormat" value="This LCD mode mimics the Mini Window in ACT.  This selector changes the export format displayed and may also be flipped through using the 2nd button of the G15 or OK button of the G19." />
+	<string key="helpPanel-lblPersonalParseFormat" value="This LCD mode will create an export with only your personal data in it, unlike the repeating format of all other combatants." />
+	<string key="helpPanel-lblSplitFile" value="As long as another program has not locked the file, ACT will attempt to rename the file with a date when opening or closing a file. (When over this size)" />
+	<!--helpPanel-lblWebServerPort -> Help Panel Mouseover-->
+	<string key="helpPanel-lblWebServerPort" value="The listening port to accept HTTP requests from.  If you use a non-standard port (80), clients must add that port to their URL notation like the following: http://127.0.0.1:80/" />
+	<!--helpPanel-LogPriority -> Help Panel Mouseover-->
+	<string key="helpPanel-LogPriority" value="This setting will change the priority of normal log parsing.  All programs have a priority, usually Normal by default, and this priority defines how much CPU time should be given to the current task.  If set to Lowest(Idle), log parsing will only take CPU time not used by other applications.  If EQ2 is running, this will be next to nothing.  Normal priority will give equal amounts of CPU time to ACT and any other task, such as EQ2.&#xA;&#xA;If ACT seems unable to keep up with log parsing tasks while EQ2 is running, you may wish to set this to Above Normal.&#xA;&#xA;For this setting to take effect, you must restart ACT or Close and Reopen the current log." />
+	<string key="helpPanel-Options_LcdColor" value="This section will define the look of the G19 specific applet.  Use the Change Font buttons to change the font/size of the specific modes.  Also be aware that changing the font size may require you to change the vertical spacing to look correct.  You may also change the basic colors of those modes.  The Spell Timer and Graph modes mimic ACT's normal settings for colors." />
+	<string key="helpPanel-Options_LcdMono" value="This section will define the look of the G15 specific applet.  Use the Font button to choose a base font to use for all screens.  To adjust the font size, use the Size Offset numeric selector for that mode.  Also adjust the vertical spacing of each line as you change the font size to meet your needs." />
+	<!--helpPanel-Options_MiniParse -> Help Panel Mouseover-->
+	<string key="helpPanel-Options_MiniParse" value="The Mini Parse window is a small text only display of the current encounter.  It may also show a graph if you click the red button in the corner.  To change the included information, create a preset the new export format." />
+	<string key="helpPanel-Options_Odbc" value="This section is for exporting ACT data into SQL datasources.  ACT uses ODBC connectivity in order to connect to these datasources and the local machine must have an ODBC driver installed to communicate to the desired type of datasource." />
+	<string key="helpPanel-Options_SelectiveParsing" value="The purpose of selective parsing is to restrict the data that appears.  The list at the left decides which combatants are used for data/exports." />
+	<string key="helpPanel-Options_Sound" value="This panel will configure the different sounds ACT will generally make for different events.  Command sounds are when you interact with ACT by typing in a game, like '/act end' or '/e end'.  Misc sounds are when ACT tries to randomly get your attention for a miscellaneous purpose.  This could be an update or even an error playing a non-existent sound.&#xA;&#xA;The bottom radio buttons change through what API ACT tries to make sounds through.  Windows API is very basic for compatibility purposes.  WMP is sufficient in most cases." />
+	<string key="helpPanel-Options_TableAttackType" value="These are the columns that will appear in the Main tab tables when clicking on TreeView nodes such as 'crush' or 'Smite'.  This table lists all of the individual combat actions of the selected skill name." />
+	<string key="helpPanel-Options_TableCombatant" value="These are the columns that will appear in the Main tab tables when clicking on TreeView nodes such as 'PlayerName' or 'MobName'.  This table lists all of the damage type categories of the combatant." />
+	<string key="helpPanel-Options_TableDamageType" value="These are the columns that will appear in the Main tab tables when clicking on TreeView nodes such as 'Outgoing Damage' or 'Healed'.  This table lists all of the skill names of the selected damage type category." />
+	<string key="helpPanel-Options_TableEnc" value="These are the columns that will appear in the Main tab tables when clicking on TreeView nodes such as 'Mobname - [1:23] 12:01:02 PM'.  This table lists all of the combatants of the selected encounter." />
+	<string key="helpPanel-Options_TableZone" value="These are the columns that will appear in the Main tab tables when clicking on TreeView nodes such as 'Import/Merge [1]' or 'ZoneName [3] 12:00:00 PM'.  This table lists all of the encounters of that node(Zone)." />
+	<string key="helpPanel-rbSParseFull" value="Full selective parsing should only be used in small groups where there are other groups near by.  When the encounter begins, the settings are locked to that encounter.  Using this feature may cause the ExtDPS calculations to differ from other copies of ACT or other parsers depending on the limiting options they use.  Once an encounter has taken place, you cannot add or remove combatants  to it without reparsing that battle.  Full selective parsing will create data gaps and should not be used while using ACT to analyze battles or statistics as it will not show a complete &quot;picture&quot; of the encounter." />
+	<!--helpPanel-SampleType -> Help Panel Mouseover-->
+	<string key="helpPanel-SampleType" value="These settings affect how many DPS plots there are along the X-Axis.  If an encounter is one minute long, and Fixed number of DPS samples(6) is selected, there will be six X-Axis plots in 10 second intervals.  If DPS samples every 15 seconds is selected, there will be four DPS plots at 15 second intervals.  Fixed number is useful for keeping a graph readable no matter how long the encounter, and fixed sample durations is useful for comparisons to other time lines." />
+	<!--helpPanel-tbCharName -> Help Panel Mouseover-->
+	<string key="helpPanel-tbCharName" value="If a log file is open this setting is ignored; however if ACT is used as an offline parser only, this setting will be used to fill in your name instead of using 'YOU'." />
+	<string key="helpPanel-tbExFileName" value="This export file name is a relative file path to the game folder or may be an absolute path." />
+	<!--helpPanel-TextFormatAddPreset -> Help Panel Mouseover-->
+	<string key="helpPanel-TextFormatAddPreset" value="Save these format options to the drop down list." />
+	<!--helpPanel-TextFormatAllies -> Help Panel Mouseover-->
+	<string key="helpPanel-TextFormatAllies" value="Allies formatting string. (First Line Format)" />
+	<!--helpPanel-TextFormatAlliesOnly -> Help Panel Mouseover-->
+	<string key="helpPanel-TextFormatAlliesOnly" value="When checked, only combatants who have proven themselves allies in the encounter will be included in the export.  This includes healing you or other proven allies, or attacking your foes.  If you do not make any allies during the encounter, all combatants will be exported." />
+	<!--helpPanel-TextFormatAlliesStats -> Help Panel Mouseover-->
+	<string key="helpPanel-TextFormatAlliesStats" value="When checked, the totals of your allies will be prefixed to the normal export." />
+	<!--helpPanel-TextFormatPlayers -> Help Panel Mouseover-->
+	<string key="helpPanel-TextFormatPlayers" value="Per-player formatting string. (Repeating Format)" />
+	<!--helpPanel-TextFormatPreset -> Help Panel Mouseover-->
+	<string key="helpPanel-TextFormatPreset" value="Replace the current formatters with a saved preset." />
+	<!--helpPanel-TextFormatRemovePreset -> Help Panel Mouseover-->
+	<string key="helpPanel-TextFormatRemovePreset" value="Remove the currently selected format from the drop down list." />
+	<!--helpPanel-TextFormatSort -> Help Panel Mouseover-->
+	<string key="helpPanel-TextFormatSort" value="The sorting method this formatting option will use." />
+	<string key="helpPanel-xmlShare" value="This section is designed for importing small snippets of settings such as Custom Triggers or Spell Timers.  Typically these snippets will be parsed from game chat but may also be copied from elsewhere and pasted.&#xA;&#xA;When an XML snippet is detected in chat, by default the character name and type of data will appear in the third(yellow) ListBox.  You may then click on the data to review it in the TextBox to the right and either import or delete the entry.&#xA;&#xA;If you wish to always import data from a particular character, you may enter their name into the TextBox above the yellow ListBox and click the above Add button.  Similarly there is a list of characters to always ignore data from.  You may temporarily disable an accept/reject entry by unchecking it or you may simply use the Remove button on either list.&#xA;&#xA;You may possibly come across an XML snippet from another source made for this feature.  Instead of having someone send it to you in a tell, you may paste it directly into the larger TextBox above the Import/Delete buttons.  It will then appear as a custom entry allowing you to Import or Delete it.&#xA;&#xA;You may create a snippet from your own data by going into either the Spell Timers options page or Custom Triggers tab, right-clicking the entry in the list and selecting Copy as Sharable XML.  If sending in EQ2 chat, the XML snippet must be by itself with no other chat or spaces." />
+	<string key="helpPanel-xmlSubscription" value="This section is for keeping up to date with external ACT settings.  XML configuration files can be put on the web and upon startup or on demand, ACT can check these files for updates(based on the timestamp).  ACT can be set to automatically import or notify the user of these updates.&#xA;&#xA;The top ListBox will contain the external URLs of the files already being watched.  To add an entry, enter the URL into the labeled TextBox, select an update option and click Add/Edit.  As update options, you can have ACT check but ignore updated files, notify you of updates using a message box or automatically import the external XML file upon detected updates.  The Query URL button will list the general contents of the URL, if valid, and list when it was marked changed.  The View in browser link will open the URL in your default web browser.&#xA;&#xA;The Check Now button will on demand check all of the URLs for changes and check-mark the updated files.  If the URL has been updated but set to be ignored, it will be marked with a gray checkmark.  You may manually check or uncheck an entry by clicking on it.&#xA;&#xA;The Update Checked button will import all entries with a normal checkmark regardless of if they were detected as changed." />
+	<!--mergedEncounterTerm-all -> The localized term for the merged All encounter at the top of zone breakdowns-->
+	<string key="mergedEncounterTerm-all" value="All" />
+	<string key="messageBox-avoidanceCopyDetail" value="&#xA;&#xA;Do you wish to copy this to the windows clipboard?" />
+	<string key="messageBox-clipboardNoText" value="The clipboard cannot be converted to plain text data." />
+	<string key="messageBox-clipConnectError" value="&#xA;&#xA;Is the specified computer running the ACT Clipboard Sharer application?&#xA;&#xA;DO NOT USE THIS FEATURE IF THE GAME AND ACT ARE RUNNING ON THE SAME SYSTEM" />
+	<string key="messageBox-cullHistory" value="{0} of {1} total records deleted." />
+	<string key="messageBox-duplicatePlugin" value="The plugin {0} appears to be loaded multiple times." />
+	<string key="messageBox-eq2FolderWizard" value="Detected EQ2 path is:&#xA;{0}&#xA;&#xA;Is this correct?" />
+	<string key="messageBox-eq2NotFound" value="EverQuest2.exe was not found in this folder.  If you are using an international version, you may need to select an 'LP_REGION_??_??' folder." />
+	<string key="messageBox-exportNoEncounters" value="Please select an encounter in the treeview." />
+	<string key="messageBox-exportNoOptions" value="Please select something to display in the export." />
+	<string key="messageBox-feedbackNoComments" value="You did not enter any comments." />
+	<string key="messageBox-feedbackNoEmail" value="You did not enter your email address.  If you need technical support or help there will be no way to contact you. &#xA;If you are reporting a rare bug, without more information from you it may be impossible to fix.&#xA;&#xA;Are you sure you wish to leave your email blank?" />
+	<string key="messageBox-feedbackShort" value="Your feedback seems to be very short.  If you are reporting a problem, the more you describe it the better.  If you do not sufficiently describe the problem, I must resort to guessing what your problem is... which may get no response at all.&#xA;&#xA;Do you wish to continue with sending the feedback?" />
+	<string key="messageBox-feedbackSuccess" value="Feedback complete." />
+	<string key="messageBox-ftpConnectionTest" value="ACT may become unresponsive during this test.  Please wait at least 30 seconds while the test is performing, and allow access through firewall notifications if they appear." />
+	<string key="messageBox-ftpTestSuccess" value="&#xA;&#xA;=============================&#xA;The test completed sucessfully.&#xA;&#xA;" />
+	<string key="messageBox-htmlNoFileAccess" value="Could not write to required files.&#xA;&#xA;{0}" />
+	<string key="messageBox-importDateTimeFail" value="Could not find the specified date range within the file." />
+	<string key="messageBox-importHistoryNoLogMatch" value="Could not find a log file for your character that likely had the date range.  Please find this file." />
+	<string key="messageBox-importParseError" value="Encountered an unrecoverable error while parsing:&#xA;{0}&#xA;Parse position: {1}&#xA;&#xA;{2}&#xA;&#xA;Ignore this error and continue?" />
+	<string key="messageBox-invalidRegex" value="There was a problem with the regular expression syntax:&#xA;{0}&#xA;&#xA;Please click the Regular Expression link or visit the forums for more help on creating Regex matches." />
+	<string key="messageBox-localSecurityPolicy" value="The application was disallowed to perform the operation due to security settings of the local machine.&#xA;If you are running this application from a networked computer, please copy and run it locally.&#xA;&#xA;" />
+	<string key="messageBox-noFileFound" value="The specified path does not exist." />
+	<string key="messageBox-odbcDropTables" value="This procedure will delete all ACT related table data and remove the tables from the database.&#xA;Once completed, this cannot be undone and the tables will have to be recreated before ACT can store data on them once again.&#xA;&#xA;Are you sure you wish to continue?" />
+	<string key="messageBox-openLogWizard" value="&#xA;Is the displayed log file the one you wish to open with ACT?" />
+	<string key="messageBox-openLogWizardNoFolder" value="No logs folder exists within this folder.  You must have logging enabled within EQ2 to use ACT.  Type &quot;/log&quot; within EQ2 to determine the logging status." />
+	<string key="messageBox-openLogWizardNoLogs" value="No logs seem to exist in this folder or subfolder.  You must have logging enabled within EQ2 to use ACT.  Type &quot;/log&quot; within EQ2 to determine the logging status." />
+	<string key="messageBox-playerRemoveError" value="Please select a name in the list to remove." />
+	<string key="messageBox-pluginCompileError" value="There were errors compiling the plugin source file.&#xA;&#xA;Please refer to the Plugin Info panel for more information." />
+	<string key="messageBox-pluginImageError" value="ACT cannot use Win32/COM assemblies as native plugins or mix 32/64 bit assemblies." />
+	<string key="messageBox-pluginInvalid" value="This assembly does not have a class that implements ACT's plugin interface, or scanning the assembly threw an error." />
+	<string key="messageBox-removePlugin" value="Are you sure you wish to remove plugin {0}?" />
+	<string key="messageBox-searchResults" value="Search returned {0} results." />
+	<!--messageBox-selectEq2Path -> ACT unable to find the EQ2 installation-->
+	<string key="messageBox-selectEq2Path" value="Your current EQ2 installation was not detectable.  Please select the folder where EQ2 resides." />
+	<string key="messageBox-sortingColumnError" value="Select a column entry to sort by." />
+	<string key="messageBoxText-fatalUnhandledException" value="An unhandled exception has occurred.  ACT may close.&#xA;Press Ctrl-C to copy this MessageBox.&#xA;&#xA;{0}" />
+	<string key="messageBoxTitle-avoidanceCopyDetail" value="Per hit average damage avoided: {0}" />
+	<string key="messageBoxTitle-clipboardNoText" value="Clipboard import failed" />
+	<string key="messageBoxTitle-clipConnectError" value="Clipboard Connection Failed" />
+	<string key="messageBoxTitle-complete" value="The operation has completed" />
+	<string key="messageBoxTitle-cullHistory" value="Cull History" />
+	<string key="messageBoxTitle-duplicatePlugin" value="Duplicate Plugin" />
+	<string key="messageBoxTitle-eq2FolderWizard" value="Detected EQ2 Folder" />
+	<string key="messageBoxTitle-eq2NotFound" value="Could not confirm folder selection" />
+	<string key="messageBoxTitle-error" value="Error" />
+	<string key="messageBoxTitle-exportNoEncounters" value="Nothing to export" />
+	<string key="messageBoxTitle-fatalUnhandledException" value="Fatal Error - Unhandled Exception" />
+	<string key="messageBoxTitle-feedbackFail" value="Feedback not submitted" />
+	<string key="messageBoxTitle-feedbackNoConnect" value="Connection to feedback server failed" />
+	<string key="messageBoxTitle-feedbackNoSend" value="Sending feedback data failed" />
+	<string key="messageBoxTitle-feedbackWarning" value="Feedback Warning" />
+	<string key="messageBoxTitle-fileError" value="File Unavailable" />
+	<string key="messageBoxTitle-ftpTestFail" value="Test incomplete" />
+	<string key="messageBoxTitle-ftpTestSuccess" value="Test complete" />
+	<string key="messageBoxTitle-htmlNoFileAccess" value="File Access Denied" />
+	<string key="messageBoxTitle-importFail" value="Parse failed" />
+	<string key="messageBoxTitle-invalidRegex" value="Invalid Regular Expression" />
+	<string key="messageBoxTitle-loadError" value="Load Error" />
+	<string key="messageBoxTitle-localSecurityPolicy" value="Security Exception" />
+	<string key="messageBoxTitle-noFileFound" value="File Not Found" />
+	<string key="messageBoxTitle-odbcDropTables" value="ACT ODBC database removal" />
+	<string key="messageBoxTitle-odbcQueryError" value="ODBC Connection Query Failed" />
+	<string key="messageBoxTitle-openLogWizard" value="Detected log file" />
+	<string key="messageBoxTitle-openLogWizardNoFolder" value="No logs folder" />
+	<string key="messageBoxTitle-openLogWizardNoLogs" value="No logfiles found" />
+	<string key="messageBoxTitle-playerRemoveError" value="No Selection" />
+	<string key="messageBoxTitle-pluginCompileError" value="Compile Error" />
+	<string key="messageBoxTitle-pluginImageError" value="Bad image format" />
+	<string key="messageBoxTitle-pluginInvalid" value="Invalid Plugin" />
+	<string key="messageBoxTitle-removePlugin" value="Remove Plugin?" />
+	<string key="messageBoxTitle-searchResults" value="Search Complete" />
+	<string key="messageBoxTitle-selectEq2Path" value="EQ2 Detection Failed" />
+	<string key="messageBoxTitle-serverStartError" value="Could not start the server" />
+	<string key="messageBoxTitle-sortingColumnError" value="Nothing Selected" />
+	<string key="messageBoxTitle-startupLogError" value="Error loading last log file" />
+	<string key="messageBoxTitle-updateAct" value="Update?" />
+	<string key="messageBoxTitle-updateCheckFail" value="ACT version check failed" />
+	<string key="messageBoxTitle-xmlPrefError" value="XML Preferences Error" />
+	<string key="messageBox-uiExport1" value="Do you wish to set the homepage of EQ2's embedded browser to ACT's encounter index?" />
+	<string key="messageBox-uiExport2" value="Do you wish to replace EQ2's browser window with one that has a collapsable interface and URL bar?" />
+	<string key="messageBox-updateAct" value="This will close the program and start the update.&#xA;Do you wish to continue?" />
+	<string key="messageBox-updateCheckFail" value="Unable to obtain version info from web.&#xA;" />
+	<string key="messageBox-xmlPrefError" value="&#xA;&#xA; Attempting default setting" />
+	<!--messageBox-xmlReadError -> A non-syntax error when reading XML setting files-->
+	<string key="messageBox-xmlReadError" value="Error while parsing XML settings: Line #{0} ({1})&#xA;{2}&#xA;&#xA; Attempting default setting" />
+	<!--messageBox-xmlSyntaxError -> The XML file was not parsable-->
+	<string key="messageBox-xmlSyntaxError" value="The XML settings file may be corrupt or unusable.  Loading defaults where applicable.&#xA;{0}" />
+	<string key="notifText-unknownAssembly" value="The following assemblies were not recognized.  If they are plugins or from plugins, they should be deleted or moved to another folder to avoid &quot;wrong version&quot; load issues.&#xD;&#xA;&#xD;&#xA;{0}" />
+	<string key="notifTitle-imageSaveException" value="Could not save image." />
+	<string key="notifTitle-unknownAssembly" value="Unknown assemblies in ACT's folder.  (Click Show to open folder)" />
+	<!--specialAttackTerm-increase -> One possible use is threat increase-->
+	<string key="specialAttackTerm-increase" value="Increase" />
+	<string key="specialAttackTerm-killing" value="Killing" />
+	<string key="specialAttackTerm-melee" value="melee" />
+	<!--specialAttackTerm-none -> What appears in the Special column of an attack when the attack is normal-->
+	<string key="specialAttackTerm-none" value="None" />
+	<string key="specialAttackTerm-nonMelee" value="non-melee" />
+	<string key="specialAttackTerm-unknown" value="unknown" />
+	<string key="specialAttackTerm-wardAbsorb" value="Absorption" />
+	<string key="specialAttackTerm-warded" value="warded" />
+	<string key="trayButton-ignore" value="Ignore For Now" />
+	<string key="trayButton-ignoreRestart" value="Ignore" />
+	<string key="trayButton-ok" value="OK" />
+	<string key="trayButton-openLogs" value="Open Logs Folder" />
+	<string key="trayButton-restartAct" value="Restart" />
+	<string key="trayText-encClearGcCollect" value="{0:0,0} bytes allocated difference" />
+	<string key="trayText-eventExceptions1" value="In the last minute, these plugins caused exceptions in event handlers:&#xA;" />
+	<string key="trayText-eventExceptions2" value="{0} [{1} time(s)]" />
+	<string key="trayText-lowDotNet" value="Your detected .NET Framework version is {0}.&#xA;&#xA;You will need to install v4.6 of the .NET Framework or greater in order for most Internet downloads/updates to work." />
+	<string key="trayText-restartACT" value="Restarting ACT is required to complete changes. &#xA;&#xA;{0}" />
+	<string key="trayTitle-eventUnhandledException" value="Event Handler Unhandled Exceptions" />
+	<string key="trayTitle-lowDotNet" value="Insufficient .NET Framework" />
+	<string key="trayTitle-restartAct" value="ACT Restart Requested" />
+	<string key="trayTitle-unhandledException" value="Unhandled Exception in ACT" />
+	<!--ui-customTriggerGeneralCategory -> There is a space before the term for sorting purposes.  Also for Spell Timer categories.-->
+	<string key="ui-customTriggerGeneralCategory" value=" General" />
+	<string key="uiFormActMain-Title0" value="{0}{1}Advanced Combat Tracker{2} - {3} - Log Time: {4} (Est. {5})" />
+	<!--uiFormActMain-Title1 -> Shown on the titlebar-->
+	<string key="uiFormActMain-Title1" value="*Combat* " />
+	<string key="uiFormActMain-Title2a" value="Log Active" />
+	<string key="uiFormActMain-Title2b" value="Log Idle" />
+	<string key="uiFormActMain-Title3" value="[Exporting]" />
+	<string key="uiFormActMain-Title4" value="[Importing]" />
+	<string key="uiFormActMain-Title5" value="[ODBC]" />
+	<string key="uiFormMiniParse-title" value="Mini Parse" />
+	<string key="uiFormMiniParse-titleCombat" value="Mini Parse - *Combat*" />
+	<string key="uiLoading-init10" value="InitACT 10...  (Setting up log file, scanning for zone/name info)" />
+	<string key="uiLoading-init11" value="InitACT 11...  (Setting up data objects)" />
+	<string key="uiLoading-init12" value="InitACT 12...  (Scanning for blocked Internet files)" />
+	<string key="uiLoading-init13" value="InitACT 13...  (Setting processor affinity)" />
+	<string key="uiLoading-init14" value="InitACT 14...  (Initializing main table style)" />
+	<string key="uiLoading-init15" value="InitACT 15...  (Validating columns and export variables)" />
+	<string key="uiLoading-init16" value="InitACT 16...  (Starting log watcher)" />
+	<string key="uiLoading-init17" value="InitACT 17...  (Resetting tab views)" />
+	<string key="uiLoading-init18" value="InitACT 18...  (Resetting combobox styles, checking parser events)" />
+	<string key="uiLoading-init19" value="InitACT 19...  (Checking for updates, setting initial viewstate)" />
+	<string key="uiLoading-init20" value="InitACT 20...  (Checking plugins)" />
+	<string key="uiLoading-init21" value="InitACT 21...  (Setting up history database)" />
+	<string key="uiLoading-init22" value="InitACT 22...  (Checking ACT's folder, XML subs)" />
+	<string key="uiLoading-init23" value="InitACT 23...  (Checking config backups)" />
+	<string key="uiLoading-initExit" value="Exiting InitACT..." />
+	<string key="uiOpMisc-logPaused" value="Parsing Paused..." />
+	<!--uiOpMisc-logPosition1 -> Shown in the Misc options panel-->
+	<string key="uiOpMisc-logPosition1" value="Reading {0}&#xA;At position: {1:0,0}." />
+	<string key="uiOpMisc-logPosition2" value=" ({0} behind.)" />
+	<string key="uiOpMisc-logPosition3" value=" ({0} CustomTrigger lines behind.)" />
+	<string key="uiOpWebServer-sessionStats" value="Session stats | During the last 10s&#xA;{0:#,0} bytes in | {3:0.00} KB/s in&#xA;{1:#,0} bytes out | {4:0.00} KB/s out&#xA;{2} unique clients | {5} unique clients" />
+	<string key="ui-processPriority" value="Normal" />
+	<string key="ui-processPriority-" value="Below Normal" />
+	<string key="ui-processPriority--" value="Lowest" />
+	<string key="ui-processPriority+" value="Above Normal" />
+	<string key="ui-soundTypeBeep" value="Beep" />
+	<string key="ui-soundTypeNone" value="None" />
+	<string key="ui-soundTypeSound" value="Sound" />
+	<string key="ui-soundTypeTts" value="TTS" />
+	<!--ui-spellTimerTooltip -> Abbreviated 's.' stands for seconds.-->
+	<string key="ui-spellTimerTooltip" value="{0} - {1}s." />
+	<!--ui-tableColumnError -> Message shown in the main table when a cell's data provider throws an exception-->
+	<string key="ui-tableColumnError" value="ERROR" />
+	<string key="ui-textExportDefault" value="[Current Default]" />
+	<string key="zoneDataTerm-import" value="Import" />
+	<string key="zoneDataTerm-importMerge" value="Import/Merge - [{0}]" />
+</InternalStrings>


### PR DESCRIPTION
The csproj no longer depends on the **Advanced Combat Tracker.exe.InternalStrings.cs** file and uses **Advanced Combat Tracker.exe.InternalStrings.xml** instead.
The *.cs file can still be directly run by ACT as a plugin.  ACT r268 and later should export this way.